### PR TITLE
[Mod] 동시성 고려 부분 추가

### DIFF
--- a/betu/src/main/java/org/example/money/PointService.java
+++ b/betu/src/main/java/org/example/money/PointService.java
@@ -7,62 +7,104 @@ import org.example.money.dto.PointChargeRequest;
 import org.example.money.dto.PointChargeResponse;
 import org.example.user.User;
 import org.example.user.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class PointService {
 
+    private static final String STATUS_DONE = "DONE";
+
     private final TossPaymentsClient toss;
     private final UserRepository userRepository;
     private final PointPurchaseRepository pointPurchaseRepository;
 
-    /** 토스 결제 승인 후 포인트 적립 (멱등/중복 적립 방지) */
-    @Transactional
+    /** 토스 결제 승인 + 포인트 적립 (멱등/동시성 대응) */
     public PointChargeResponse confirmAndCredit(Long userId, PointChargeRequest req) {
-        // 0) 기본 검증
+        validateRequest(req);
+
+        // 1) 트랜잭션 밖에서 승인 (네트워크 호출 중 DB 락 보유 방지)
+        TossPaymentResponse res = confirmOutsideTx(req);
+
+        // 2) 응답 교차 검증 (위·변조/오용 방지)
+        validateTossResponseMatchesRequest(req, res);
+
+        // 3) 트랜잭션 안에서 "유니크 제약 + 사용자 행 잠금"으로 동시성 제어
+        return creditTx(userId, res);
+    }
+
+    private void validateRequest(PointChargeRequest req) {
         if (req.getAmount() == null || req.getAmount() <= 0) {
             throw new IllegalArgumentException("금액/포인트가 올바르지 않습니다.");
         }
+        if (req.getOrderId() == null || req.getPaymentKey() == null) {
+            throw new IllegalArgumentException("결제 식별자가 누락되었습니다.");
+        }
+    }
 
-        // 1) 이미 처리된 paymentKey면 멱등 처리(2번 적립 금지)
-        if (pointPurchaseRepository.findByPaymentKey(req.getPaymentKey()).isPresent()) {
-            // 이미 적립된 건이므로 현재 유저 포인트만 리턴
+    private TossPaymentResponse confirmOutsideTx(PointChargeRequest req) {
+        try {
+            // Idempotency-Key로 orderId 사용 (Toss 중복 호출 방지)
+            return toss.confirm(req.getPaymentKey(), req.getOrderId(), req.getAmount(), req.getOrderId());
+        } catch (RuntimeException e) {
+            // 이미 승인된 결제라면 조회로 동기화
+            if (e.getMessage() != null && e.getMessage().contains("ALREADY_PROCESSED_PAYMENT")) {
+                return toss.getPayment(req.getPaymentKey());
+            }
+            throw e;
+        }
+    }
+
+    private void validateTossResponseMatchesRequest(PointChargeRequest req, TossPaymentResponse res) {
+        if (!req.getOrderId().equals(res.getOrderId())) {
+            throw new SecurityException("주문 식별자가 일치하지 않습니다.");
+        }
+        if (!req.getPaymentKey().equals(res.getPaymentKey())) {
+            throw new SecurityException("결제 키가 일치하지 않습니다.");
+        }
+        // 승인 상태 확인
+        if (!STATUS_DONE.equals(res.getStatus())) {
+            throw new IllegalStateException("결제가 승인 상태(DONE)가 아닙니다. status=" + res.getStatus());
+        }
+        // 금액 일치 확인: 최초 승인 적립은 totalAmount 기준
+        if (!Objects.equals(res.getTotalAmount(), req.getAmount())) {
+            throw new SecurityException("승인 금액(totalAmount)이 요청 금액과 일치하지 않습니다.");
+        }
+    }
+
+    /** 실제 적립(트랜잭션 내부): 유니크 제약 + 사용자 행 잠금으로 중복/경합 방지 */
+    @Transactional
+    protected PointChargeResponse creditTx(Long userId, TossPaymentResponse res) {
+        try {
+            // (A) 사용자 행 비관적 락 -> 포인트 합산 충돌 방지
+            User user = userRepository.findByIdForUpdate(userId)
+                    .orElseThrow(() -> new EntityNotFoundException("사용자 없음"));
+
+            // (B) 먼저 구매 이력 저장(UNIQUE 제약으로 멱등 보장)
+            PointPurchase purchase = PointPurchase.builder()
+                    .user(user)
+                    .amount(res.getTotalAmount())      // 결제 총 승인 금액
+                    .pointAmount(res.getTotalAmount())  // 포인트 적립 금액 = totalAmount
+                    .paymentKey(res.getPaymentKey())
+                    .orderId(res.getOrderId())
+                    .status(PointPurchase.Status.APPROVED)
+                    .build();
+            pointPurchaseRepository.save(purchase); // 중복이면 여기서 DataIntegrityViolationException
+
+            // (C) 포인트 적립 (동일 트랜잭션 내 원자성)
+            user.addPoint(res.getTotalAmount());
+
+            return new PointChargeResponse(res.getTotalAmount(), user.getPoint());
+
+        } catch (DataIntegrityViolationException dup) {
+            // (D) paymentKey/orderId UNIQUE 충돌 → 이미 처리됨(멱등)
             User u = userRepository.findById(userId)
                     .orElseThrow(() -> new EntityNotFoundException("사용자 없음"));
             return new PointChargeResponse(0L, u.getPoint());
         }
-
-        // 2) 토스 결제 승인 (Idempotency-Key = orderId)
-        TossPaymentResponse res;
-        try {
-            res = toss.confirm(req.getPaymentKey(), req.getOrderId(), req.getAmount(), req.getOrderId());
-        } catch (RuntimeException e) {
-            // 이미 승인된 경우 동기화
-            if (e.getMessage() != null && e.getMessage().contains("ALREADY_PROCESSED_PAYMENT")) {
-                res = toss.getPayment(req.getPaymentKey());
-            } else {
-                throw e;
-            }
-        }
-
-        // 3) 유저 포인트 적립
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 없음"));
-        user.addPoint(req.getAmount());
-
-        // 4) 구매 이력 저장 (중복 적립 방지용)
-        PointPurchase purchase = PointPurchase.builder()
-                .user(user)
-                .amount(req.getAmount())
-                .pointAmount(req.getAmount())
-                .paymentKey(res.getPaymentKey())
-                .orderId(res.getOrderId())
-                .status(PointPurchase.Status.APPROVED)
-                .build();
-        pointPurchaseRepository.save(purchase);
-
-        return new PointChargeResponse(req.getAmount(), user.getPoint());
     }
 }

--- a/betu/src/main/java/org/example/user/UserRepository.java
+++ b/betu/src/main/java/org/example/user/UserRepository.java
@@ -1,6 +1,10 @@
 package org.example.user;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserName(String userName);
     Optional<User> findByUserEmail(String email);
     Optional<User> findByRefreshToken(String refreshToken);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.userId = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }


### PR DESCRIPTION
#### 1. 외부 API 호출 분리
- Toss 결제 승인 API 호출(toss.confirm)은 트랜잭션 밖에서 실행
- 이유: 네트워크 지연 중에 DB 락을 오래 쥐고 있으면 교착·성능 저하 위험 → 호출 후 응답을 검증한 뒤에만 트랜잭션 시작

#### 2. 응답 교차 검증 (위·변조/오용 방지)
- orderId, paymentKey, totalAmount, status를 요청값과 비교
- Toss 응답 위·변조, 다른 사람 결제 키 사용, 금액 불일치 같은 문제를 사전에 차단
- 승인 상태(status == "DONE")일 때만 포인트 적립

#### 3. 멱등성 보장
- 중복 요청이 들어오면 DataIntegrityViolationException을 잡아 멱등 처리(0포인트 적립, 현재 포인트 반환)
- 즉, 같은 결제가 여러 번 호출돼도 1회만 적립

#### 4. 동시성 제어 (포인트 누적 안전성)
- UserRepository.findByIdForUpdate()를 사용해 해당 사용자 행에 비관적 락을 걸고 포인트를 증가시킴
- 동시에 여러 요청이 같은 유저를 수정하더라도 한 번에 한 트랜잭션만 통과 → 레이스 컨디션 방지

#### 5. 트랜잭션 원자성
- 구매 이력 저장 + 포인트 적립을 하나의 트랜잭션으로 묶음
- 둘 중 하나라도 실패하면 전체 롤백 → 데이터 불일치 방지
- 예: 이력 저장만 되고 포인트 적립이 안 되는 상황 차단

#### 6. 실패·중복 케이스 처리
- Toss에서 "ALREADY_PROCESSED_PAYMENT" 에러 발생 시 → toss.getPayment()로 동기화 후 처리
- 즉, 클라이언트/네트워크 중복 요청에도 안정적으로 대응